### PR TITLE
fixed: Move element queries out of displaySubscribedMessage function

### DIFF
--- a/static/js/builder.js
+++ b/static/js/builder.js
@@ -4,6 +4,8 @@ const quickViewDiv        = document.querySelector("#quick-view");
 const quickViewContainer  = document.querySelector("#quick-view .container");
 const subscribeFormDiv    = document.querySelector(".subscribe__form");
 const subscribeInfo       = document.querySelector(".subscribe__information");
+const h2Element           = subscribeInfo.querySelector("h2");
+const pElement            = subscribeInfo.querySelector("p");
 const subscribeContainer  = document.querySelector(".subscribe .container");
 
 
@@ -389,13 +391,15 @@ function displaySubscribedMessage() {
     if (!(subscribeInfo instanceof HTMLElement)) {
         throw new Error("The element is not an HTML element");
     }
-    const h2Element       = subscribeInfo.querySelector("h2");
-    const pElement        = subscribeInfo.querySelector("p");
-
+    
+    if (!(h2Element instanceof HTMLElement) || !(pElement instanceof HTMLElement)) {
+        throw new Error("One or more of the elements is not an HTML element");
+    }
+    
     h2Element.textContent = "You're All Set!";
-    pElement.textContent  = "Thank you for subscribing! You've successfully joined our newsletter and received your 30% off. Stay tuned for the latest updates on events, sales, special offers, and promotions!"
-   
+    pElement.textContent = "Thank you for subscribing! You've successfully joined our newsletter and received your 30% off. Stay tuned for the latest updates on events, sales, special offers, and promotions!";
 }
+
 
 function centerSubscribeText() {
     if (!(subscribeContainer instanceof HTMLElement) ) {


### PR DESCRIPTION
Description:
- Moved the following element queries out of the displaySubscribedMessage function to make them global: [1] const h2Element = subscribeInfo.querySelector("h2"); [2] const pElement = subscribeInfo.querySelector("p");
- This change ensures that the querySelector is only called once, rather than each time the function is called.

- Updated the element validation logic in the displaySubscribedMessage function.
- Implemnted (||) operator to validate h2Element and pElement instances.
- Ensures that an error is thrown if either h2Element or pElement is not an HTMLElement.