### PR TITLE
Fixed issue with missing ratingDiv causing product reviews not to dis…

### DIFF
--- a/static/js/reviews.js
+++ b/static/js/reviews.js
@@ -10,7 +10,11 @@ const ratingStars        = document.querySelectorAll(".product-ratings a");
 addEventListenerToStar();
 
 function addEventListenerToStar() {
-    ratingDiv.addEventListener("click", handleStarClick);
+
+    if (ratingDiv) {
+        ratingDiv.addEventListener("click", handleStarClick);
+    }
+   
 }
 
 


### PR DESCRIPTION
…play

- The list of product reviews was not showing because the page couldn't find the ratingDiv element.
- This issue occurred because the JavaScript file was trying to access ratingDiv on a different page where it didn't exist.
- This prevented the "Home -> My account -> Manage your review -> Leave a product review or feedback -> Add or edit a review" flow from displaying correctly.
- To rectify the error, an if-statement was implemented to ensure ratingDiv is present before adding the event listener.

Original code:
function addEventListenerToStar() {
    ratingDiv.addEventListener("click", handleStarClick);
}

Updated code:
function addEventListenerToStar() {
    if (ratingDiv) {
        ratingDiv.addEventListener("click", handleStarClick);
    }
}