### PR TITLE
Ratings review star not showing #23

### DIFF
--- a/static/js/reviews.js
+++ b/static/js/reviews.js
@@ -4,6 +4,7 @@ import { getItemFromLocalStorage,  saveToLocalStorage, redirectToNewPage } from 
 
 const ratingDiv  = document.querySelector(".product-ratings");
 
+
 addEventListenerToStar();
 
 
@@ -19,8 +20,10 @@ function addEventListenerToStar() {
 function handleStarClick(e) {
     if (e.target.tagName === 'A' || e.target.tagName === 'IMG') {
         e.preventDefault();
+
         const star = e.target.closest('a');
         renderStar(parseInt(star.dataset.value));
+
     }
 }
 

--- a/templates/account/reviews/add-review.html
+++ b/templates/account/reviews/add-review.html
@@ -353,6 +353,7 @@
     </footer>
 
     <script src="../../../static/js/add-review.js" type="module"></script>
+    <script src="../../../static/js/reviews.js" type="module"></script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.12.2/dist/sweetalert2.all.min.js"></script>
 
 


### PR DESCRIPTION
Issue Fixed: Star Rating Reviews Not Displaying Correctly

****Resolution**:**
I have resolved the issue by refactoring the `review.js` file. Specifically, I moved some components to a new file called `add-review.js`. 

****Reason for Refactor**:**
The issue was caused by JavaScript files associated with other pages still being called when the user navigated to different pages. This led to errors because the expected elements were not found on those pages, preventing other JavaScript scripts from running.

****Specific Fix**:**
The problem was that I had not included the following script line in the `add-review.html` file:
```html
<script src="../../../static/js/reviews.js" type="module"></script>
```
By adding this line, `add-review.html` now has access to the necessary JavaScript, and everything is working within acceptable parameters.

---

****Details**:**
- **Refactoring**: Components were moved to `add-review.js` to ensure that scripts are only loaded where needed, preventing errors.
- **Script Inclusion**: Ensured the correct script file is included in the `add-review.html` file.

Everything is now functioning as expected. 

