### PR TITLE
Replaced login and register links with a logged-in message on all page except the index.html

### DIFF
--- a/templates/account/account/account.html
+++ b/templates/account/account/account.html
@@ -150,8 +150,7 @@
 
                         </div>
                     </div>
-                    <a href="#" aria-label="Login to your account" class="nav-link">Login</a>
-                    <a href="#" aria-label="Register a new account" class="nav-link">Register</a>
+                    <a href="#" aria-label="logged in" class="nav-link logged-in">Hi, Egbie (logged in)</a>
                 </div>
             </div>
         </div>
@@ -541,6 +540,7 @@
             </div>
         </div>
     </footer>
+    
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.12.2/dist/sweetalert2.all.min.js"></script>
 
 

--- a/templates/account/financial-management/financial-management.html
+++ b/templates/account/financial-management/financial-management.html
@@ -151,8 +151,8 @@
 
                         </div>
                     </div>
-                    <a href="#" aria-label="Login to your account" class="nav-link">Login</a>
-                    <a href="#" aria-label="Register a new account" class="nav-link">Register</a>
+                    <a href="#" aria-label="logged in" class="nav-link logged-in">Hi, Egbie (logged in)</a>
+
                 </div>
             </div>
         </div>
@@ -362,8 +362,7 @@
     </footer>
 
    
-
-
+    <script src="static/js/modules/auth.js" type="module"></script>
 
 </body>
 

--- a/templates/account/orders/orders.html
+++ b/templates/account/orders/orders.html
@@ -150,8 +150,8 @@
 
                         </div>
                     </div>
-                    <a href="#" aria-label="Login to your account" class="nav-link">Login</a>
-                    <a href="#" aria-label="Register a new account" class="nav-link">Register</a>
+                    <a href="#" aria-label="logged in" class="nav-link logged-in">Hi, Egbie (logged in)</a>
+
                 </div>
             </div>
         </div>
@@ -726,6 +726,7 @@
             </div>
         </div>
     </footer>
+
 
     <script src="../../../static/js/pages/orders.js" type="module"></script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.12.2/dist/sweetalert2.all.min.js"></script>

--- a/templates/account/orders/view-item.html
+++ b/templates/account/orders/view-item.html
@@ -150,8 +150,8 @@
 
                         </div>
                     </div>
-                    <a href="#" aria-label="Login to your account" class="nav-link">Login</a>
-                    <a href="#" aria-label="Register a new account" class="nav-link">Register</a>
+                    <a href="#" aria-label="logged in" class="nav-link logged-in">Hi, Egbie (logged in)</a>
+
                 </div>
             </div>
         </div>
@@ -425,7 +425,7 @@
             </div>
         </div>
     </footer>
-
+  
     <script src="../../../static/js/pages/view-item.js" type="module"></script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.12.2/dist/sweetalert2.all.min.js"></script>
 

--- a/templates/account/refund/refund-management.html
+++ b/templates/account/refund/refund-management.html
@@ -149,8 +149,8 @@
 
                         </div>
                     </div>
-                    <a href="#" aria-label="Login to your account" class="nav-link">Login</a>
-                    <a href="#" aria-label="Register a new account" class="nav-link">Register</a>
+                    <a href="#" aria-label="logged in" class="nav-link logged-in">Hi, Egbie (logged in)</a>
+
                 </div>
             </div>
         </div>
@@ -313,6 +313,7 @@
     </footer>
 
    
+
 
 </body>
 

--- a/templates/account/reviews/add-or-edit-review.html
+++ b/templates/account/reviews/add-or-edit-review.html
@@ -150,8 +150,8 @@
 
                         </div>
                     </div>
-                    <a href="#" aria-label="Login to your account" class="nav-link">Login</a>
-                    <a href="#" aria-label="Register a new account" class="nav-link">Register</a>
+                    <a href="#" aria-label="logged in" class="nav-link logged-in">Hi, Egbie (logged in)</a>
+
                 </div>
             </div>
         </div>
@@ -312,6 +312,7 @@
             </div>
         </div>
     </footer>
+
 
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.12.2/dist/sweetalert2.all.min.js"></script>
 

--- a/templates/account/reviews/add-review.html
+++ b/templates/account/reviews/add-review.html
@@ -150,8 +150,8 @@
 
                         </div>
                     </div>
-                    <a href="#" aria-label="Login to your account" class="nav-link">Login</a>
-                    <a href="#" aria-label="Register a new account" class="nav-link">Register</a>
+                    <a href="#" aria-label="logged in" class="nav-link logged-in">Hi, Egbie (logged in)</a>
+
                 </div>
             </div>
         </div>
@@ -369,6 +369,7 @@
             </div>
         </div>
     </footer>
+
 
     <script src="../../../static/js/modules/add-review.js" type="module"></script>
     <script src="../../../static/js/modules/reviews.js" type="module"></script>

--- a/templates/account/reviews/display-reviews.html
+++ b/templates/account/reviews/display-reviews.html
@@ -150,8 +150,8 @@
 
                         </div>
                     </div>
-                    <a href="#" aria-label="Login to your account" class="nav-link">Login</a>
-                    <a href="#" aria-label="Register a new account" class="nav-link">Register</a>
+                    <a href="#" aria-label="logged in" class="nav-link logged-in">Hi, Egbie (logged in)</a>
+
                 </div>
             </div>
         </div>
@@ -325,6 +325,7 @@
         </div>
     </footer>
 
+   
     <script src="../../../static/js/modules/reviews.js" type="module"></script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.12.2/dist/sweetalert2.all.min.js"></script>
 

--- a/templates/account/reviews/reviews-and-feedback.html
+++ b/templates/account/reviews/reviews-and-feedback.html
@@ -150,8 +150,9 @@
 
                         </div>
                     </div>
-                    <a href="#" aria-label="Login to your account" class="nav-link">Login</a>
-                    <a href="#" aria-label="Register a new account" class="nav-link">Register</a>
+                    
+                    <a href="#" aria-label="logged in" class="nav-link logged-in">Hi, Egbie (logged in)</a>
+
                 </div>
             </div>
         </div>


### PR DESCRIPTION
…es except index.html

Removed:
    <a href="#" aria-label="Login to your account" class="nav-link">Login</a>
    <a href="#" aria-label="Register a new account" class="nav-link">Register</a>

Replaced with:
    <a href="#" aria-label="logged in" class="nav-link logged-in">Hi, Egbie (logged in)</a>

Note: This is a static link, not a dynamic one, because the backend is not yet implemented.

This change was made because, once the backend is implemented, users won't see these pages unless logged in, and they will see their name instead of static links.