### PR TITLE
- ***Autofocus and Password Strength Checker Activation:***

### DIFF
--- a/index.html
+++ b/index.html
@@ -2798,7 +2798,7 @@
 
 
                         <a href="templates/account/auth/forgotten-password.html" class="login-link">Forgotten password?</a>
-                        <a href="#" class="login-link">Not registered - click here?</a>
+                        <a href="#" class="login-link" id="not-registered-link">Not registered - click here?</a>
                         
                         <button type="submit" class="auth-button text-capitalize">login</button>
                      </form>
@@ -2837,7 +2837,7 @@
                         <label for="register-confirm-password">Confirm Password</label>
                         <input type="password" name="password" id="register-confirm-password" required>
 
-                        <a href="#" class="register-link auth-link already-registered">Have account - click here?</a>
+                        <a href="#" class="register-link auth-link already-registered" id="have-an-account-link">Have account - click here?</a>
                         
                         <button type="submit" class="auth-button text-capitalize register-btn">Register</button>
                      </form>

--- a/static/js/modules/auth.js
+++ b/static/js/modules/auth.js
@@ -5,6 +5,8 @@ const registerLinkElement             = document.getElementById("register-link")
 const closeWindowIconElement          = document.querySelector(".auth-close-icon");
 const closeRegistrationIconElement    = document.getElementById("reg-close-icon");
 const passwordElement                 = document.getElementById("register-password");
+const haveAnAccountLink               = document.getElementById("have-an-account-link");
+const notRegisteredLink               = document.getElementById("not-registered-link");
 
 const confirmPasswordElement          = document.getElementById("register-confirm-password");
 const hasCapitalElement               = document.getElementById('has-capital');
@@ -14,7 +16,9 @@ const hasNumberElement                = document.getElementById('has-number');
 const hasMinLengthElement             = document.getElementById('has-min-length');
 const strongPasswordElement           = document.getElementById("is-success");
 const doPasswordsMatch                = document.getElementById("is-password-a-match");
-const inputElementField               = document.getElementById('inputField');
+const inputElementField               = document.getElementById('inputField');7
+
+
 
 import PasswordStrengthChecker from "../utils/password.js";
 
@@ -24,7 +28,36 @@ loginLinkElement?.addEventListener("click", handleLoginClick);
 closeWindowIconElement?.addEventListener("click", handleCloseIcon);
 
 registerLinkElement?.addEventListener("click", handleRegisterClick);
+
 closeRegistrationIconElement.addEventListener("click", handleRegistrationCloseIcon);
+
+
+haveAnAccountLink?.addEventListener("click", handleHaveAnAccountLink);
+notRegisteredLink?.addEventListener("click", handleNotRegisteredLink); 
+
+
+function handleHaveAnAccountLink(e) {
+    e.preventDefault();
+
+    if (!registerAuthenticationContainer) {
+        throw new Error("The registration element div wasn't found!!!");
+    };
+
+    registerAuthenticationContainer.classList.remove("show");
+    loginAuthenticationContainer.classList.add("show");
+}
+
+
+function handleNotRegisteredLink(e) {
+    e.preventDefault();
+
+    if (!loginAuthenticationContainer) {
+        throw new Error("The login element div wasn't found!!!");
+    };
+
+    registerAuthenticationContainer.classList.add("show");
+    loginAuthenticationContainer.classList.remove("show");
+}
 
 
 
@@ -76,8 +109,20 @@ passwordElement.addEventListener("input", () => {
     
 })
 
+passwordElement.addEventListener("click", () => {
+    passwordStrengthHelper(passwordElement, " Current using password field");
+    doPasswordMatch(passwordElement, confirmPasswordElement);
+    
+})
+
 
 confirmPasswordElement.addEventListener("input", () => {
+    passwordStrengthHelper(confirmPasswordElement, " Current using confirm password field");
+    doPasswordMatch(passwordElement, confirmPasswordElement);
+
+})
+
+confirmPasswordElement.addEventListener("click", () => {
     passwordStrengthHelper(confirmPasswordElement, " Current using confirm password field");
     doPasswordMatch(passwordElement, confirmPasswordElement);
 


### PR DESCRIPTION
  - The password strength checker is now activated when the user clicks on the password or confirm password fields, not just when they enter text.
  - For example, if a user has already entered a password and then clicks into the confirm password field, the password strength checker will activate and display the strength of the entered password. Previously, this functionality was only triggered when text was entered.

- ***Updated Navigation Links:***
  - The "Not registered - click here" link now correctly redirects users to the registration form.
  - Similarly, the "Have an account - click here" link now redirects users to the login form.

- ***Password Visibility Toggle:***
  - Add a feature that allows users to toggle the visibility of their entered password.