### PR TITLE
feat: Change shipping options from radio buttons to checkboxes

### DIFF
--- a/templates/account/project-management/add-new-product/shipping-and-delivery.html
+++ b/templates/account/project-management/add-new-product/shipping-and-delivery.html
@@ -210,43 +210,43 @@
                             <input type="number" name="weight" id="weight" min="1" max="10000" step="0.1">
 
 
-                            <legend>Shipping Option</legend>
+                            <legend>Shipping Options</legend>
                             <hr class="dividor">
                             <fieldset class="shipping-options">
 
 
                                 <label>
-                                    <input type="radio" name="shipping" value="standard" checked>
+                                    <input type="checkbox" name="shipping" value="standard">
                                     Standard Shipping (3-5 business days) - £3.99
                                 </label><br>
 
                                 <label>
-                                    <input type="radio" name="shipping" value="express">
+                                    <input type="checkbox" name="shipping" value="express">
                                     Express Shipping (1-2 business days) - £5.99
                                 </label><br>
 
                                 <label>
-                                    <input type="radio" name="shipping" value="next-day">
+                                    <input type="checkbox" name="shipping" value="next-day">
                                     Next-Day Delivery - £9.99
                                 </label><br>
 
                                 <label>
-                                    <input type="radio" name="shipping" value="same-day">
+                                    <input type="checkbox" name="shipping" value="same-day">
                                     Same-Day Delivery (order by 2 PM) - £14.99
                                 </label><br>
 
                                 <label>
-                                    <input type="radio" name="shipping" value="click-collect">
+                                    <input type="checkbox" name="shipping" value="click-collect">
                                     Click and Collect (1-2 days) - Free
                                 </label><br>
 
                                 <label>
-                                    <input type="radio" name="shipping" value="weekend">
+                                    <input type="checkbox" name="shipping" value="weekend">
                                     Weekend Delivery - £7.99
                                 </label><br>
 
                                 <label>
-                                    <input type="radio" name="shipping" value="free">
+                                    <input type="checkbox" name="shipping" value="free">
                                     Free Shipping (orders over £50) - Free
                                 </label><br>
 


### PR DESCRIPTION
Turned the radio buttons for the shipping options into checkboxes. The idea behind this change is that the owner should be able to offer more than one shipping option for a given product.