### PR TITLE
fix: Correct parameter in `saveToLocalStorage` function call in `add-…

### DIFF
--- a/static/js/components/add-product.js
+++ b/static/js/components/add-product.js
@@ -258,7 +258,7 @@ function handleFormSubmission(form, pageNumber) {
 
 
 function handleFormComplete(form, formEntries, pageNumber) {
-    saveToLocalStorage(form.id, formEntries, pageNumber);
+    saveToLocalStorage(form.id, formEntries, true);
     redirectToNewPage(addNewProductPages[pageNumber]);
 }
 


### PR DESCRIPTION
…product.js`

- Fixed a minor issue where `saveToLocalStorage(form.id, formEntries, pagenmuber)` was incorrectly passing a number instead of a boolean.
- Updated the call to `saveToLocalStorage(form.id, formEntries, true)` to explicitly pass `true`, indicating that data should be stringified before storage.
- The previous implementation worked due to type coercion but by using a boolean value it improves code clarity and correctness.

Original:
saveToLocalStorage(form.id, formEntries, pagenmuber)

Updated:
saveToLocalStorage(form.id, formEntries, true)