### PR TITLE
feat: Add functionality to retrieve and persist user-entered form data

### DIFF
--- a/static/css/csss.css
+++ b/static/css/csss.css
@@ -3010,7 +3010,6 @@ legend {
     cursor: pointer;
     background-color: #007bff; 
     padding: 8px;
-    /* font-size: 1rem; */
     font-size: var(--font-size-sm);
     text-transform: capitalize;
     color: white;

--- a/static/js/components/add-product.js
+++ b/static/js/components/add-product.js
@@ -1,9 +1,12 @@
 import addNewProductPages from "../pages/pages.js";
-import { redirectToNewPage } from "../utils/utils.js";
 import { minimumCharactersToUse } from "./characterCounter.js";
-import { getItemFromLocalStorage, saveToLocalStorage, getAllCheckBoxElementsValue } from "../utils/utils.js";
+import { getItemFromLocalStorage, saveToLocalStorage, getAllCheckBoxElementsValue, 
+        redirectToNewPage, getCurrentUrl } from "../utils/utils.js";
 import { getFormEntries } from "../utils/formUtils.js";
 import { populateSelectField } from "../builders/formBuilder.js";
+
+
+window.prevPage = prevPage;
 
 
 
@@ -35,6 +38,10 @@ imageAndMediaForm?.addEventListener("submit", handleImageAndMediaForm);
 shippingAndDeliveryForm?.addEventListener("submit", handleShippingAndDeliveryForm);
 seoAndMetaForm?.addEventListener("submit", handleSeoAndMetaForm);
 additionInformationForm?.addEventListener("submit", handleAdditionalFormInfo);
+
+
+// update the current form values when the user hits prevPage button
+
 
 
 // field selectors for textArea fields
@@ -119,17 +126,55 @@ function handleSelectClick(e) {
 
 function prevPage(event, pageNumber) {
     event.preventDefault();
+
     const page = addNewProductPages[parseInt(pageNumber)];
+    
 
     if (!page) {
         throw new Error("Something went wrong and the page number couldn't be found!!!");
     }
 
     redirectToNewPage(page);
+  
+  
 }
 
 
-window.prevPage = prevPage;
+
+
+function updateFormValue() {
+    const currentPage = getCurrentUrl()?.pop();
+    
+    const formElements = {
+        "basic-product-information.html": basicForm,
+        "detailed-description-specs.html": detailedForm,
+        "pricing-inventory.html": pricingInventoryForm,
+        "images-and-media.html": imageAndMediaForm,
+        "shipping-and-delivery.html": shippingAndDeliveryForm,
+        "SEO-and-meta-information.html": seoAndMetaForm,
+        "additonal-information.html": additionInformationForm,
+    }
+
+    if (formElements[currentPage] === "undefined") {
+        return;
+    }
+  
+  
+    const formDetails   = formElements[currentPage];
+    const productValues = getItemFromLocalStorage(formDetails.id, true);
+
+    // Iterate over the form elements and update their values using their saved data
+    for (let element of formDetails.elements) {
+        // console.log(element.name)
+        if (element.name) {
+            element.value = productValues[element.name];
+        }
+    }
+
+}
+
+
+
 
 
 
@@ -265,8 +310,7 @@ function handleFormComplete(form, formEntries, pageNumber) {
 
 
 
-
-
+window.onload = updateFormValue;
 
 
 

--- a/static/js/utils/utils.js
+++ b/static/js/utils/utils.js
@@ -91,6 +91,11 @@ function getAllCheckBoxElementsValue(checkboxElements) {
     });
 
     return selectedValues;
+};
+
+
+function getCurrentUrl() {
+    return window.location.href.split("/");
 }
 
   
@@ -102,4 +107,5 @@ export {
     redirectToNewPage,
     getFormattedCurrentDate,
     getAllCheckBoxElementsValue,
+    getCurrentUrl,
 };


### PR DESCRIPTION
- Introduced `updateFormValue` function to restore previously entered form data.
- Previously, navigating away from the form (e.g., using the 'Previous' button) would result in data loss, requiring users to re-enter their information again. This update allows users to move between pages (both forward and backward) without losing their data.
- Currently, all data is restored except for "multiple checkboxes," which require manual re-selection. This is due to custom handling of checkboxes, and future updates will address the preservation of checkbox states.

The data is not also stored in "add discount" input because this will be shown based on the user clicking "yes" or "no", and at the moment there isn't a functionality to handle that.