### PR TITLE
Fruit and veg  project management#add new product

### DIFF
--- a/static/js/components/add-product.js
+++ b/static/js/components/add-product.js
@@ -1,7 +1,7 @@
 import addNewProductPages from "../pages/pages.js";
 import { minimumCharactersToUse } from "./characterCounter.js";
 import { getItemFromLocalStorage, saveToLocalStorage, getAllCheckBoxElementsValue, 
-        redirectToNewPage, getCurrentUrl } from "../utils/utils.js";
+        redirectToNewPage, getCurrentPage } from "../utils/utils.js";
 import { getFormEntries } from "../utils/formUtils.js";
 import { populateSelectField } from "../builders/formBuilder.js";
 
@@ -143,7 +143,7 @@ function prevPage(event, pageNumber) {
 
 
 function updateFormValue() {
-    const currentPage = getCurrentUrl()?.split("/")?.pop();
+    const currentPage = getCurrentPage();
     // console.log(currentPage)
     
     const formElements = {

--- a/static/js/components/add-product.js
+++ b/static/js/components/add-product.js
@@ -144,7 +144,7 @@ function prevPage(event, pageNumber) {
 
 function updateFormValue() {
     const currentPage = getCurrentPage();
-    // console.log(currentPage)
+    // console.log(currentPage);
     
     const formElements = {
         "basic-product-information.html": basicForm,
@@ -154,25 +154,25 @@ function updateFormValue() {
         "shipping-and-delivery.html": shippingAndDeliveryForm,
         "SEO-and-meta-information.html": seoAndMetaForm,
         "additonal-information.html": additionInformationForm,
-    }
+    };
 
-    if (formElements[currentPage] === "undefined") {
+    if (!currentPage || formElements[currentPage] === undefined) {
+        console.warn(`No form element found for current page: ${currentPage}`);
         return;
     }
   
-  
-    const formDetails   = formElements[currentPage];
+    const formDetails = formElements[currentPage];
     const productValues = getItemFromLocalStorage(formDetails.id, true);
 
     // Iterate over the form elements and update their values using their saved data
     for (let element of formDetails.elements) {
-        // console.log(element.name)
+       
         if (element.name) {
-            element.value = productValues[element.name];
+            element.value = productValues[element.name] || '';   // Fallback to empty string if no value
         }
     }
-
 }
+
 
 
 

--- a/static/js/utils/utils.js
+++ b/static/js/utils/utils.js
@@ -98,6 +98,10 @@ function getCurrentUrl() {
     return window.location.href;
 }
 
+function getCurrentPage() {
+    return getCurrentUrl()?.split("/")?.pop();
+}
+
   
 export {
     generateSessionKey,
@@ -108,4 +112,5 @@ export {
     getFormattedCurrentDate,
     getAllCheckBoxElementsValue,
     getCurrentUrl,
+    getCurrentPage,
 };


### PR DESCRIPTION

refactor: Introduce `getCurrentPage` for URL abstraction

- Added `getCurrentPage()` function to encapsulate the logic of extracting the current page from the URL. 
 Users can now retrieve the current page without needing to understand or manage the underlying URL processing details for extracting the current page through the split method.
- Refactored `updateFormValue()` to use `getCurrentPage()` instead of performing URL splitting directly.
- Updated `updateFormValue()` to handle cases where `currentPage` or form elements might be `undefined`.
- Changed the check from comparing with the string `"undefined"` to the actual `undefined` type for accurate results.
- Added a fallback to an empty string (`|| ''`) when setting form element values to handle missing data gracefully.
- Added a warning log for debugging purposes if no form element is found for the current page.


```javascript
function getCurrentPage() {
    return getCurrentUrl()?.split("/")?.pop();
}