### PR TITLE
fix: Ensure `createProductTable` handles empty orders correctly

### DIFF
--- a/static/js/components/createReviewTable.js
+++ b/static/js/components/createReviewTable.js
@@ -13,7 +13,7 @@ function createProductTable(orders, show=true) {
     if (!productReviewTable) {
         return;
     }
-    if (!show) {
+    if (!show || orders.length === 0) {
         productReviewTable.style.display = "none";
         pagination.style.display         = "none";
         notFound.style.display           = "block";
@@ -88,8 +88,6 @@ function getReviewStatus(product) {
       reviewsFound = false;
       reviews = orders;
     }
-
-
 
     for (let review of reviews) {
         if (!reviewsFound) {

--- a/static/js/modules/reviews.js
+++ b/static/js/modules/reviews.js
@@ -89,7 +89,6 @@ function handleDropDown(e) {
             pendingReviews === null ? createProductTable(pendingReviews, false) : createProductTable(pendingReviews, true);
             break;
         case selectTarget.toLowerCase() === "not-reviewed":
-            
             createProductTable(getNotReviewed());
             break;
         case selectTarget.toLowerCase() === "latest":

--- a/static/js/modules/reviews.js
+++ b/static/js/modules/reviews.js
@@ -89,6 +89,7 @@ function handleDropDown(e) {
             pendingReviews === null ? createProductTable(pendingReviews, false) : createProductTable(pendingReviews, true);
             break;
         case selectTarget.toLowerCase() === "not-reviewed":
+            
             createProductTable(getNotReviewed());
             break;
         case selectTarget.toLowerCase() === "latest":


### PR DESCRIPTION
fix: Ensure `createProductTable` handles empty orders correctly

Updated the condition to the `createProductTable` function to check if `(!show || orders.length === 0)`. This ensures that if there are no orders to display, the table will be removed, and a "The search result was not found" message will be shown.
