### PR TITLE
Added "Go Live" and "Deactivate" functionality to product table

### DIFF
--- a/static/js/pages/product-info.js
+++ b/static/js/pages/product-info.js
@@ -22,7 +22,7 @@ function createTable() {
         return;
     }
 
-    const headers = ["ID", "Product Name", "Category", "Stock Quantity", "is Live", "Date created", "Edit", "Delete"];
+    const headers = ["ID", "Product Name", "Category", "Stock Quantity", "is Live", "Date created", "Action", "Edit"];
 
     const table    = document.createElement("table");
     const tHeaders = createTableHeaderRow(headers);
@@ -89,9 +89,10 @@ function createTableRowData(productData) {
         ""  // placeholder for the delete link
     ];
 
+    const linkText = isLive ? "Deactivate" : "Go live";
     const additionalInformation = {
-        6: createTableLink({ linkText: "Edit", productID: id, className: "edit-link", handleClick: handleEditClick }),
-        7: createTableLink({ linkText: "Delete", productID: id, className: "delete-link", handleClick: handleDeleteLinkClick }),
+        6: createTableLink({ linkText: linkText, productID: id, className: "go-live", handleClick: handleVisibilityToggle }),
+        7: createTableLink({ linkText: "Edit", productID: id, className: "delete-link", handleClick: handleDeleteLinkClick }),
     };
 
     return createTableRow(listOfDataColumns, additionalInformation);
@@ -99,7 +100,7 @@ function createTableRowData(productData) {
 
 
 
-function handleEditClick(e) {
+function handleVisibilityToggle(e) {
     e.preventDefault();
     console.log(e);
 


### PR DESCRIPTION
- Implemented: Added `Go Live` and `Deactivate` options to the product table to allow admins to easily manage product visibility and availability.
- Replaced: The previous `Edit` option has been replaced with these new visibility management options for improved clarity and functionality.
- New Feature: Introduced `handleVisibilityToggle` function to manage the toggling between "Go Live" and "Deactivate" states. Note that this function is currently not active and will be integrated in a future update.

Reason: These updates provide a more intuitive way for admins to control whether products are visible and available for purchase, which enhances the overall product management UI experience.

Note:
The links are not yet active so clicking on them does nothing.