### PR TITLE
 Update `handleClearButton`: Move `clearTable` and `showMessage` functions into respective alerts

### DIFF
--- a/static/js/pages/product-info.js
+++ b/static/js/pages/product-info.js
@@ -150,7 +150,9 @@ function handleClearButton() {
             cancelButtonColor: "#d33",
         },
         func: () => {
-            removeItemFromLocalStorage(SAVE_TABLE_NAME)
+            removeItemFromLocalStorage(SAVE_TABLE_NAME);
+            clearTable();
+            showMessage("You have not yet added a product");
             // console.log("Test")
         }, 
         followUpAlertAttrs: {

--- a/static/js/pages/product-info.js
+++ b/static/js/pages/product-info.js
@@ -132,7 +132,10 @@ function handleClearButton() {
             text: "There are no items available to delete.",
             icon: "info",
             confirmButtonText: "OK",
-        });        
+        });   
+        
+        clearTable();
+        showMessage("You have not yet added a product");
         return;
     };
 
@@ -158,8 +161,7 @@ function handleClearButton() {
         
     });
 
-    clearTable();
-    showMessage("You have not yet added a product");
+  
 }
 
 createTable();

--- a/static/js/utils/alerts.js
+++ b/static/js/utils/alerts.js
@@ -82,6 +82,7 @@ const AlertUtils = {
         }).then((result) => {
             if (result.isConfirmed) {
                 const funcResult = func();
+                console.log(funcResult)
                 if (funcResult && typeof funcResult.then === 'function') {
                     // If func() is a promise, wait for it to resolve
                     funcResult.then(() => {


### PR DESCRIPTION

Update `handleClearButton`: Move `clearTable` and `showMessage` functions into respective alerts

- Moved `clearTable` and `showMessage("You have not yet added a product")` into the first and second alert dialogs within `handleClearButton`.
- **First Alert**: Executes `clearTable` and shows the message only when there are no items and the user presses "Clear."
- **Second Alert**: Executes `clearTable` and shows the message when the user confirms the deletion in the modal.

**Expected Behaviour:**
- The `clearTable` function and the message are shown only in the appropriate scenarios described above.

**Unexpected Behaviour:**
- When `clearTable` and `showMessage` were moved outside the alert dialogs but still within `handleClearButton`, the cancel button triggered these functions, 
showing the message "You have not yet added" even though there were items in the table.

