### PR TITLE
Fruit and veg#product management view new added product  links functionalities

### DIFF
--- a/static/js/pages/product-info.js
+++ b/static/js/pages/product-info.js
@@ -37,7 +37,6 @@ function createTable() {
         showMessage("You have not yet added a product");
         return;
     }
-
    
     const headers     = ["ID", "Product Name", "Category", "Stock Quantity", "is Live", "Date created", "Action", "Action"];
     const table       = document.createElement("table");
@@ -176,7 +175,8 @@ function handleClearButton() {
         followUpAlertAttrs: {
             title: "Completed!",
             text: "The action has been successfully completed.",
-            icon: "success"
+            icon: "success",
+            confirmButtonText: "Great"
         }
         
     });

--- a/static/js/utils/alerts.js
+++ b/static/js/utils/alerts.js
@@ -86,16 +86,17 @@ const AlertUtils = {
                 if (funcResult && typeof funcResult.then === 'function') {
                     // If func() is a promise, wait for it to resolve
                     funcResult.then(() => {
-                        Swal.fire({
+                        this.showAlert({
                             title: followUpAlertAttrs.title,
                             text: followUpAlertAttrs.text,
                             icon: followUpAlertAttrs.icon,
                             confirmButtonText: confirmButtonText,
                         })
+                       
                     });
                 } else {
                     // If func() is not a promise, immediately show the follow-up alert
-                    Swal.fire({
+                    this.showAlert({
                         title: followUpAlertAttrs.title,
                         text: followUpAlertAttrs.text,
                         icon: followUpAlertAttrs.icon,


### PR DESCRIPTION

Reverted changes to use `methods` in the showConfirmationAlert method. 
The issue occurred because changes were stashed and pulled on a different branch, 
which caused the context to not be preserved. The problem has been fixed by updating 
the function to use below function method within the object:

```
this.showAlert({
    title: followUpAlertAttrs.title,
    text: followUpAlertAttrs.text,
    icon: followUpAlertAttrs.icon,
    confirmButtonText: confirmButtonText,
});

```